### PR TITLE
Add wifi fields for source detection

### DIFF
--- a/dragonsync.py
+++ b/dragonsync.py
@@ -240,6 +240,14 @@ def zmq_to_cot(
                 # Check if message is a list (original format) or dict (ESP32 format)
                 if isinstance(message, list):
                     # Original format: list of dictionaries
+                    drone_info['index'] = 0
+                    drone_info['runtime'] = 0
+
+                    # Try to extract index and runtime from the first list item or the entire message
+                    if message and isinstance(message[0], dict):
+                        drone_info['index'] = message[0].get('index', 0)
+                        drone_info['runtime'] = message[0].get('runtime', 0)
+
                     for item in message:
                         if isinstance(item, dict):
                             # Process each item as a dictionary
@@ -281,6 +289,9 @@ def zmq_to_cot(
                             logger.error("Unexpected item type in message list; expected dict.")
 
                 elif isinstance(message, dict):
+                    drone_info['index'] = message.get('index', 0)
+                    drone_info['runtime'] = message.get('runtime', 0)  
+
                     if "AUX_ADV_IND" in message:
                         # Get RSSI from raw message
                         if "rssi" in message["AUX_ADV_IND"]:
@@ -292,6 +303,7 @@ def zmq_to_cot(
 
                     # ESP32 format: single dictionary
                     if 'Basic ID' in message:
+                        id_type = message['Basic ID'].get('id_type')
                         drone_info['id_type'] = message['Basic ID'].get('id_type')
                         drone_info['mac'] = message['Basic ID'].get('MAC')
                         drone_info['rssi'] = message['Basic ID'].get('RSSI')
@@ -334,9 +346,6 @@ def zmq_to_cot(
                     if drone_id in drone_manager.drone_dict:
                         drone = drone_manager.drone_dict[drone_id]
                         drone.update(
-                            mac=drone_info.get('mac', ""),
-                            rssi=drone_info.get('rssi', 0.0),
-                            id_type=drone_info.get('id_type', ""),
                             lat=drone_info.get('lat', 0.0),
                             lon=drone_info.get('lon', 0.0),
                             speed=drone_info.get('speed', 0.0),
@@ -345,9 +354,14 @@ def zmq_to_cot(
                             height=drone_info.get('height', 0.0),
                             pilot_lat=drone_info.get('pilot_lat', 0.0),
                             pilot_lon=drone_info.get('pilot_lon', 0.0),
+                            description=drone_info.get('description', ""),
+                            mac=drone_info.get('mac', ""),
+                            rssi=drone_info.get('rssi', 0),
                             home_lat=drone_info.get('home_lat', 0.0),
                             home_lon=drone_info.get('home_lon', 0.0),
-                            description=drone_info.get('description', "")
+                            id_type=drone_info.get('id_type', ""),
+                            index=drone_info.get('index', 0),
+                            runtime=drone_info.get('runtime', 0)
                         )
                         logger.debug(f"Updated drone: {drone_id}")
                     else:
@@ -355,18 +369,20 @@ def zmq_to_cot(
                             id=drone_info['id'],
                             lat=drone_info.get('lat', 0.0),
                             lon=drone_info.get('lon', 0.0),
-                            id_type=drone_info.get('id_type', ""),
                             speed=drone_info.get('speed', 0.0),
                             vspeed=drone_info.get('vspeed', 0.0),
                             alt=drone_info.get('alt', 0.0),
                             height=drone_info.get('height', 0.0),
                             pilot_lat=drone_info.get('pilot_lat', 0.0),
                             pilot_lon=drone_info.get('pilot_lon', 0.0),
-                            home_lat=drone_info.get('home_lat', 0.0),
-                            home_lon=drone_info.get('home_lon', 0.0),
                             description=drone_info.get('description', ""),
                             mac=drone_info.get('mac', ""),
-                            rssi=drone_info.get('rssi', 0)
+                            rssi=drone_info.get('rssi', 0),
+                            home_lat=drone_info.get('home_lat', 0.0),
+                            home_lon=drone_info.get('home_lon', 0.0),
+                            id_type=drone_info.get('id_type', ""),
+                            index=drone_info.get('index', 0),
+                            runtime=drone_info.get('runtime', 0)
                         )
                         drone_manager.update_or_add_drone(drone_id, drone)
                         logger.debug(f"Added new drone: {drone_id}")

--- a/drone.py
+++ b/drone.py
@@ -36,9 +36,12 @@ class Drone:
     """Represents a drone and its telemetry data."""
 
     def __init__(self, id: str, lat: float, lon: float, speed: float, vspeed: float,
-                 alt: float, height: float, pilot_lat: float, pilot_lon: float, description: str, mac: str, rssi: int, home_lat: float = 0.0, home_lon: float = 0.0, id_type: str = ""):
+                 alt: float, height: float, pilot_lat: float, pilot_lon: float, description: str, mac: str, rssi: int, 
+                 home_lat: float = 0.0, home_lon: float = 0.0, id_type: str = "", index: int = 0, runtime: int = 0):
         self.id = id
         self.id_type = id_type
+        self.index = index
+        self.runtime = runtime
         self.mac = mac
         self.rssi = rssi
         self.lat = lat
@@ -57,7 +60,7 @@ class Drone:
 
     def update(self, lat: float, lon: float, speed: float, vspeed: float, alt: float,
                height: float, pilot_lat: float, pilot_lon: float, description: str, mac: str, rssi: int,
-               home_lat: float = 0.0, home_lon: float = 0.0, id_type: str = ""):
+               home_lat: float = 0.0, home_lon: float = 0.0, id_type: str = "", index: int = 0, runtime: int = 0):
         """Updates the drone's telemetry data."""
         self.lat = lat
         self.lon = lon
@@ -74,6 +77,8 @@ class Drone:
         self.last_update_time = time.time()
         self.mac = mac
         self.rssi = rssi
+        self.index = index
+        self.runtime = runtime
 
     def to_cot_xml(self, stale_offset: Optional[float] = None) -> bytes:
         """Converts the drone's telemetry data to a Cursor-on-Target (CoT) XML message."""
@@ -117,7 +122,7 @@ class Drone:
             f"Location/Vector: [Speed: {self.speed} m/s, Vert Speed: {self.vspeed} m/s, "
             f"Geodetic Altitude: {self.alt} m, Height AGL: {self.height} m], "
             f"System: [Operator Lat: {self.pilot_lat}, Operator Lon: {self.pilot_lon}, "
-            f"Home Lat: {self.home_lat}, Home Lon: {self.home_lon}]"
+            f"Home Lat: {self.home_lat}, Home Lon: {self.home_lon}, Index: {self.index}, Runtime: {self.runtime}]"
         )
         remarks_text = xml.sax.saxutils.escape(remarks_text)
         etree.SubElement(detail, 'remarks').text = remarks_text


### PR DESCRIPTION
## Why

- No previous way to distinguish on multicast if it was a WiFi or BT message
- Adds ability to show correct format in mobile app and elsewhere

## What

- Added a check to grab the two variables only seen in WiFi from ZMQ_decoder, `index` and `runtime`
- Minor housekeeping formatting

## Integation

- From observation it seems adding two remarks will not interfere with existing codebases