### PR TITLE
feat(dragonsync): MQTT/HA integration (device_trackers, sensors, availability) + cleanup

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,11 +1,11 @@
 [SETTINGS]
 
-# ZMQ Configuration
+# ────────── ZMQ Configuration ──────────
 zmq_host = 127.0.0.1
 zmq_port = 4224
 zmq_status_port = 4225
 
-# TAK Server Configuration (optional)
+# ────────── TAK Server Configuration (optional) ──────────
 tak_host =
 tak_port =
 # tcp or udp (leave blank to ignore if host/port unset)
@@ -14,25 +14,34 @@ tak_tls_p12 =
 tak_tls_p12_pass =
 tak_tls_skip_verify = true
 
-# Multicast Configuration (optional)
+# ────────── Multicast Configuration (optional) ──────────
 tak_multicast_addr = 239.2.3.1
 tak_multicast_port = 6969
 enable_multicast = true
 tak_multicast_interface = 0.0.0.0
 multicast_ttl = 1
 
-# Operational Parameters
+# ────────── Operational Parameters ──────────
 # Minimum seconds between CoT sends per drone
 rate_limit = 3.0
 max_drones = 30
 inactivity_timeout = 60.0
 enable_receive = false
 
-# MQTT (optional)
+# ────────── MQTT Configuration (optional) ──────────
 mqtt_enabled = false
 mqtt_host = 127.0.0.1
 mqtt_port = 1883
+# Aggregate topic (all drones pushed here as individual JSON messages)
 mqtt_topic = wardragon/drones
+# Per-drone topics (disabled by default)
+mqtt_per_drone_enabled = false
+mqtt_per_drone_base = wardragon/drone
+# Home Assistant discovery (disabled by default)
+mqtt_ha_enabled = false
+mqtt_ha_prefix = homeassistant
+mqtt_ha_device_base = wardragon_drone
+# Authentication / TLS
 mqtt_username =
 mqtt_password =
 mqtt_tls = false
@@ -40,8 +49,10 @@ mqtt_ca_file =
 mqtt_certfile =
 mqtt_keyfile =
 mqtt_tls_insecure = false
+# Retain messages by default (good for HA dashboards)
+mqtt_retain = true
 
-# Lattice (optional)
+# ────────── Lattice (optional) ──────────
 lattice_enabled = false
 lattice_token =
 # Either base URL, e.g. https://your.env.anduril.cloud

--- a/dragonsync.py
+++ b/dragonsync.py
@@ -650,19 +650,20 @@ if __name__ == "__main__":
         "mqtt_host": args.mqtt_host if hasattr(args, "mqtt_host") and args.mqtt_host is not None else get_str(config_values.get("mqtt_host", "127.0.0.1")),
         "mqtt_port": args.mqtt_port if hasattr(args, "mqtt_port") and args.mqtt_port is not None else get_int(config_values.get("mqtt_port", 1883)),
         "mqtt_topic": args.mqtt_topic if hasattr(args, "mqtt_topic") and args.mqtt_topic is not None else get_str(config_values.get("mqtt_topic", "wardragon/drones")),
-         "mqtt_username": args.mqtt_username if hasattr(args, "mqtt_username") and args.mqtt_username is not None else get_str(config_values.get("mqtt_username")),
+        "mqtt_username": args.mqtt_username if hasattr(args, "mqtt_username") and args.mqtt_username is not None else get_str(config_values.get("mqtt_username")),
         "mqtt_password": args.mqtt_password if hasattr(args, "mqtt_password") and args.mqtt_password is not None else get_str(config_values.get("mqtt_password")),
         "mqtt_tls": args.mqtt_tls if hasattr(args, "mqtt_tls") and args.mqtt_tls is not None else get_bool(config_values.get("mqtt_tls", False)),
         "mqtt_ca_file": args.mqtt_ca_file if hasattr(args, "mqtt_ca_file") and args.mqtt_ca_file is not None else get_str(config_values.get("mqtt_ca_file")),
         "mqtt_certfile": args.mqtt_certfile if hasattr(args, "mqtt_certfile") and args.mqtt_certfile is not None else get_str(config_values.get("mqtt_certfile")),
         "mqtt_keyfile": args.mqtt_keyfile if hasattr(args, "mqtt_keyfile") and args.mqtt_keyfile is not None else get_str(config_values.get("mqtt_keyfile")),
         "mqtt_tls_insecure": args.mqtt_tls_insecure if hasattr(args, "mqtt_tls_insecure") and args.mqtt_tls_insecure is not None else get_bool(config_values.get("mqtt_tls_insecure", False)),
-        "mqtt_per_drone_enabled": args.mqtt_per_drone_enabledxif hasattr(args, "mqtt_per_drone_enabled") and args.mqtt_per_drone_enabled is not None else get_bool(config_values.get("mqtt_per_drone_enabled", False)),
+        "mqtt_retain": args.mqtt_retain if hasattr(args, "mqtt_retain") and args.mqtt_retain is not None else get_bool(config_values.get("mqtt_retain", True)),
+        "mqtt_per_drone_enabled": args.mqtt_per_drone_enabled if hasattr(args, "mqtt_per_drone_enabled") and args.mqtt_per_drone_enabled is not None else get_bool(config_values.get("mqtt_per_drone_enabled", False)),
         "mqtt_per_drone_base": args.mqtt_per_drone_base if hasattr(args, "mqtt_per_drone_base") and args.mqtt_per_drone_base is not None else get_str(config_values.get("mqtt_per_drone_base", "wardragon/drone")),
         "mqtt_ha_enabled": args.mqtt_ha_enabled if hasattr(args, "mqtt_ha_enabled") and args.mqtt_ha_enabled is not None else get_bool(config_values.get("mqtt_ha_enabled", False)),
-        "mqtt_ha_prefix": args.mqtt_ha_prefif if hasattr(args, "mqtt_ha_prefix") and args.mqtt_ha_prefix is not None else get_str(config_values.get("mqtt_ha_prefix", "homeassistant")),
+        "mqtt_ha_prefix": args.mqtt_ha_prefix if hasattr(args, "mqtt_ha_prefix") and args.mqtt_ha_prefix is not None else get_str(config_values.get("mqtt_ha_prefix", "homeassistant")),
         "mqtt_ha_device_base": args.mqtt_ha_device_base if hasattr(args, "mqtt_ha_device_base") and args.mqtt_ha_device_base is not None else get_str(config_values.get("mqtt_ha_device_base", "wardragon_drone")),
-        
+
         # ---- Lattice (optional) config block ----
         "lattice_enabled": args.lattice_enabled or get_bool(config_values.get("lattice_enabled"), False),
         # Environment (Authorization) token

--- a/dragonsync.py
+++ b/dragonsync.py
@@ -627,7 +627,7 @@ if __name__ == "__main__":
     parser.add_argument("--lattice-token", type=str, help="Lattice environment token (or env LATTICE_TOKEN / ENVIRONMENT_TOKEN)")
     parser.add_argument("--lattice-base-url", type=str, help="Full base URL, e.g. https://lattice-XXXX.env.sandboxes.developer.anduril.com (or env LATTICE_BASE_URL)")
     parser.add_argument("--lattice-endpoint", type=str, help="Endpoint host only (no scheme) to build base_url, e.g. lattice-XXXX.env.sandboxes.developer.anduril.com (or env LATTICE_ENDPOINT)")
-    parser.add_argument("--lattice-sandbox-token", type:str, help="Sandboxes Bearer token (or env SANDBOXES_TOKEN / LATTICE_SANDBOX_TOKEN)")
+    parser.add_argument("--lattice-sandbox-token", type=str, help="Sandboxes Bearer token (or env SANDBOXES_TOKEN / LATTICE_SANDBOX_TOKEN)")
     parser.add_argument("--lattice-source-name", type=str, help="Provenance source name (or env LATTICE_SOURCE_NAME)")
     parser.add_argument("--lattice-drone-rate", type=float, help="Drone publish rate to Lattice (Hz)")
     parser.add_argument("--lattice-wd-rate", type=float, help="WarDragon publish rate to Lattice (Hz)")

--- a/manager.py
+++ b/manager.py
@@ -154,12 +154,20 @@ class DroneManager:
 
         # Housekeeping: drop inactive drones
         for drone_id in to_remove:
+            for s in self.extra_sinks:
+                try:
+                    if hasattr(s, "mark_inactive"):
+                        s.mark_inactive(drone_id)
+                except Exception as e:
+                    logger.warning("Sink mark_inactive failed for %s (sink=%s): %s", drone_id, s, e)
+
             try:
                 self.drones.remove(drone_id)
             except ValueError:
                 pass
             self.drone_dict.pop(drone_id, None)
             logger.debug("Removed drone: %s", drone_id)
+
 
     def close(self):
         """Give every sink a chance to cleanup (e.g., stop MQTT loops, flush, etc.)."""

--- a/manager.py
+++ b/manager.py
@@ -24,233 +24,148 @@ SOFTWARE.
 
 import time
 from collections import deque
-from typing import Optional, List
+from typing import Optional, List, Dict
 import logging
 import math
-import json
-try:
-    import paho.mqtt.client as mqtt
-except ImportError:
-    mqtt = None
 
 from drone import Drone
 from messaging import CotMessenger
 
 logger = logging.getLogger(__name__)
 
+
 class DroneManager:
-    """Manages a collection of drones and handles their updates."""
+    """Manages a collection of drones and handles their updates.
+
+    All outputs (MQTT/HA/Lattice/etc.) are delegated to objects passed via
+    `extra_sinks`. A sink may implement:
+      - publish_drone(drone)
+      - publish_pilot(drone_id, lat, lon, alt)
+      - publish_home(drone_id,  lat, lon, alt)
+      - close()
+    """
 
     def __init__(
         self,
-        max_drones=30,
-        rate_limit=1.0,
-        inactivity_timeout=60.0,
+        max_drones: int = 30,
+        rate_limit: float = 1.0,
+        inactivity_timeout: float = 60.0,
         cot_messenger: Optional[CotMessenger] = None,
-        mqtt_enabled=False,
-        mqtt_host='127.0.0.1',
-        mqtt_port=1883,
-        mqtt_topic='wardragon/drones',
-        # --- Enhancement: MQTT auth/TLS options ---
-        mqtt_username: Optional[str] = None,
-        mqtt_password: Optional[str] = None,
-        mqtt_tls: bool = False,
-        mqtt_ca_file: Optional[str] = None,
-        mqtt_certfile: Optional[str] = None,
-        mqtt_keyfile: Optional[str] = None,
-        mqtt_tls_insecure: bool = False,
-        # ------------------------------------------
-        extra_sinks: Optional[List] = None
+        extra_sinks: Optional[List] = None,
     ):
-        self.drones = deque(maxlen=max_drones)
-        self.drone_dict = {}
+        self.drones: deque[str] = deque(maxlen=max_drones)
+        self.drone_dict: Dict[str, Drone] = {}
         self.rate_limit = rate_limit
         self.inactivity_timeout = inactivity_timeout
         self.cot_messenger = cot_messenger
-        self.mqtt_enabled = mqtt_enabled
-        self.mqtt_topic = mqtt_topic
-        self.mqtt_client = None
-        self.extra_sinks = extra_sinks or []
-
-        if self.mqtt_enabled:
-            if mqtt is None:
-                logger.critical("MQTT support requested, but paho-mqtt is not installed!")
-                raise ImportError("paho-mqtt required for MQTT support")
-
-            # Create client
-            self.mqtt_client = mqtt.Client()
-
-            # Route paho internal logs to our logger when available (nice during -d)
-            try:
-                self.mqtt_client.enable_logger(logger)  # paho >=1.6
-            except Exception:
-                # Older paho may not have enable_logger; fall back to on_log callback below
-                pass
-
-            # Callbacks for connection lifecycle and publish acks
-            def _on_connect(c, u, flags, rc, props=None):
-                # rc==0 means success
-                logger.info("MQTT connected rc=%s flags=%s", rc, flags)
-
-            def _on_disconnect(c, u, rc, props=None):
-                logger.warning("MQTT disconnected rc=%s", rc)
-
-            def _on_publish(c, u, mid):
-                logger.debug("MQTT published mid=%s", mid)
-
-            def _on_log(c, u, level, buf):
-                # Visible at DEBUG level; shows socket/TLS/errors, etc.
-                logger.debug("MQTT on_log: %s", buf)
-
-            self.mqtt_client.on_connect = _on_connect
-            self.mqtt_client.on_disconnect = _on_disconnect
-            self.mqtt_client.on_publish = _on_publish
-            self.mqtt_client.on_log = _on_log
-
-            # Username/password over plain TCP (TLS optional below)
-            if mqtt_username is not None:
-                self.mqtt_client.username_pw_set(mqtt_username, mqtt_password)
-
-            # TLS (kept as-is; only activates if you pass mqtt_tls=True)
-            if mqtt_tls:
-                try:
-                    self.mqtt_client.tls_set(
-                        ca_certs=mqtt_ca_file,
-                        certfile=mqtt_certfile,
-                        keyfile=mqtt_keyfile,
-                    )
-                    self.mqtt_client.tls_insecure_set(bool(mqtt_tls_insecure))
-                except Exception as e:
-                    logger.critical(f"Failed to configure MQTT TLS: {e}")
-                    raise
-
-            # Connect and start background loop
-            try:
-                self.mqtt_client.connect(mqtt_host, int(mqtt_port), keepalive=60)
-                self.mqtt_client.loop_start()
-
-                # Briefly wait to confirm connection (if supported by this paho version)
-                connected = False
-                deadline = time.time() + 3.0
-                is_conn = getattr(self.mqtt_client, "is_connected", None)
-                while time.time() < deadline and callable(is_conn) and not self.mqtt_client.is_connected():
-                    time.sleep(0.05)
-                if callable(is_conn):
-                    connected = self.mqtt_client.is_connected()
-
-                if connected:
-                    logger.info(
-                        "MQTT: connected to %s:%s (username=%s)",
-                        mqtt_host, mqtt_port, "<set>" if mqtt_username else "<empty>"
-                    )
-                else:
-                    logger.warning("MQTT: no connect confirmation within timeout; check broker/creds/port")
-            except Exception as e:
-                logger.critical(f"Failed to connect to MQTT broker: {e}")
-                self.mqtt_enabled = False
+        self.extra_sinks = list(extra_sinks or [])
 
     def update_or_add_drone(self, drone_id: str, drone_data: Drone):
         """Updates an existing drone or adds a new one to the collection."""
         if drone_id not in self.drone_dict:
             if len(self.drones) >= self.drones.maxlen:
                 oldest_drone_id = self.drones.popleft()
-                del self.drone_dict[oldest_drone_id]
+                self.drone_dict.pop(oldest_drone_id, None)
                 logger.debug(f"Removed oldest drone: {oldest_drone_id}")
             self.drones.append(drone_id)
             self.drone_dict[drone_id] = drone_data
             drone_data.last_sent_time = 0.0
             logger.debug(f"Added new drone: {drone_id}")
         else:
+            # Same as before, but now also track freq
             self.drone_dict[drone_id].update(
-                lat=drone_data.lat, lon=drone_data.lon, speed=drone_data.speed,
-                vspeed=drone_data.vspeed, alt=drone_data.alt, height=drone_data.height,
-                pilot_lat=drone_data.pilot_lat, pilot_lon=drone_data.pilot_lon,
-                description=drone_data.description, mac=drone_data.mac, rssi=drone_data.rssi
+                lat=drone_data.lat,
+                lon=drone_data.lon,
+                speed=drone_data.speed,
+                vspeed=drone_data.vspeed,
+                alt=drone_data.alt,
+                height=drone_data.height,
+                pilot_lat=drone_data.pilot_lat,
+                pilot_lon=drone_data.pilot_lon,
+                description=drone_data.description,
+                mac=drone_data.mac,
+                rssi=drone_data.rssi,
+                freq=getattr(drone_data, "freq", None),
             )
             logger.debug(f"Updated drone: {drone_id}")
 
     def send_updates(self):
-        """Sends regular CoT updates to the TAK server or multicast address."""
-        current_time = time.time()
-        drones_to_remove = []
+        """Sends rate-limited CoT updates and dispatches the full Drone to sinks."""
+        now = time.time()
+        to_remove: List[str] = []
 
         for drone_id in list(self.drones):
             drone = self.drone_dict[drone_id]
-            time_since_update = current_time - drone.last_update_time
+            age = now - drone.last_update_time
 
-            if time_since_update > self.inactivity_timeout:
-                drones_to_remove.append(drone_id)
-                logger.debug(f"Drone {drone_id} inactive for {time_since_update:.2f}s. Removing from tracking.")
+            if age > self.inactivity_timeout:
+                to_remove.append(drone_id)
+                logger.debug("Drone %s inactive for %.2fs. Removing.", drone_id, age)
                 continue
 
+            # position delta for diagnostics
             delta_lat = drone.lat - drone.last_sent_lat
             delta_lon = drone.lon - drone.last_sent_lon
-            position_change = math.sqrt(delta_lat ** 2 + delta_lon ** 2)
+            position_change = math.hypot(delta_lat, delta_lon)
 
-            if current_time - drone.last_sent_time >= self.rate_limit:
-                cot_xml = drone.to_cot_xml(
-                    stale_offset=self.inactivity_timeout - time_since_update
-                )
-                if self.cot_messenger:
-                    self.cot_messenger.send_cot(cot_xml)
+            if (now - drone.last_sent_time) >= self.rate_limit:
+                stale_offset = self.inactivity_timeout - age
 
-                if self.mqtt_enabled and self.mqtt_client:
+                # 1) CoT main event
+                try:
+                    cot_xml = drone.to_cot_xml(stale_offset=stale_offset)
+                    if self.cot_messenger and cot_xml:
+                        self.cot_messenger.send_cot(cot_xml)
+                except Exception as e:
+                    logger.warning("CoT send failed for %s: %s", drone_id, e)
+
+                # 2) Sinks (MQTT/HA/Lattice/etc.)
+                for s in self.extra_sinks:
                     try:
-                        payload = json.dumps(vars(drone), default=str)
-                        logger.debug(
-                            "MQTT publish topic=%s bytes=%d id=%s",
-                            self.mqtt_topic, len(payload), getattr(drone, "id", "")
-                        )
-                        info = self.mqtt_client.publish(self.mqtt_topic, payload)
-                        # Surface non-success codes (rare on qos=0 but helpful)
-                        if info.rc != mqtt.MQTT_ERR_SUCCESS:
-                            logger.warning("MQTT publish returned rc=%s", info.rc)
+                        if hasattr(s, "publish_drone"):
+                            s.publish_drone(drone)
+                        if (getattr(drone, "pilot_lat", 0.0) or getattr(drone, "pilot_lon", 0.0)) and hasattr(s, "publish_pilot"):
+                            s.publish_pilot(drone_id, drone.pilot_lat, drone.pilot_lon, 0.0)
+                        if (getattr(drone, "home_lat", 0.0) or getattr(drone, "home_lon", 0.0)) and hasattr(s, "publish_home"):
+                            s.publish_home(drone_id, drone.home_lat, drone.home_lon, 0.0)
                     except Exception as e:
-                        logger.warning(f"Failed to publish to MQTT: {e}")
+                        logger.warning("Sink publish failed for %s (sink=%s): %s", drone_id, s, e)
+
+                # 3) Pilot/Home CoT
+                try:
+                    if drone.pilot_lat != 0.0 or drone.pilot_lon != 0.0:
+                        pilot_xml = drone.to_pilot_cot_xml(stale_offset=stale_offset)
+                        if self.cot_messenger and pilot_xml:
+                            self.cot_messenger.send_cot(pilot_xml)
+                    if drone.home_lat != 0.0 or drone.home_lon != 0.0:
+                        home_xml = drone.to_home_cot_xml(stale_offset=stale_offset)
+                        if self.cot_messenger and home_xml:
+                            self.cot_messenger.send_cot(home_xml)
+                except Exception as e:
+                    logger.warning("Pilot/Home CoT send failed for %s: %s", drone_id, e)
 
                 drone.last_sent_lat = drone.lat
                 drone.last_sent_lon = drone.lon
-                drone.last_sent_time = current_time
-                logger.debug(f"Sent CoT update for drone {drone_id} (position change: {position_change:.8f}).")
+                drone.last_sent_time = now
+                logger.debug(
+                    "Sent update for drone %s (position change: %.8f).",
+                    drone_id, position_change
+                )
 
-                # ── Minimal change: give sinks the whole Drone object so they see ALL fields ──
-                if self.extra_sinks:
-                    for s in self.extra_sinks:
-                        try:
-                            s.publish_drone(drone)
-                            # optional pilot/home pins if the sink supports them (keep 4-arg form)
-                            if (getattr(drone, "pilot_lat", 0.0) or getattr(drone, "pilot_lon", 0.0)) and hasattr(s, "publish_pilot"):
-                                s.publish_pilot(drone_id, drone.pilot_lat, drone.pilot_lon, 0.0)
-                            if (getattr(drone, "home_lat", 0.0) or getattr(drone, "home_lon", 0.0)) and hasattr(s, "publish_home"):
-                                s.publish_home(drone_id, drone.home_lat, drone.home_lon, 0.0)
-                        except Exception as e:
-                            logger.warning(f"Extra sink publish failed for {drone_id}: {e}")
-
-                if drone.pilot_lat != 0.0 or drone.pilot_lon != 0.0:
-                    pilot_xml = drone.to_pilot_cot_xml(
-                        stale_offset=self.inactivity_timeout - time_since_update
-                    )
-                    if self.cot_messenger:
-                        self.cot_messenger.send_cot(pilot_xml)
-                    logger.debug(f"Sent pilot CoT update for drone {drone_id}.")
-
-                if drone.home_lat != 0.0 or drone.home_lon != 0.0:
-                    home_xml = drone.to_home_cot_xml(
-                        stale_offset=self.inactivity_timeout - time_since_update
-                    )
-                    if self.cot_messenger:
-                        self.cot_messenger.send_cot(home_xml)
-                    logger.debug(f"Sent home CoT update for drone {drone_id}.")
-
-        for drone_id in drones_to_remove:
-            self.drones.remove(drone_id)
-            del self.drone_dict[drone_id]
-            logger.debug(f"Removed drone: {drone_id}")
+        # Housekeeping: drop inactive drones
+        for drone_id in to_remove:
+            try:
+                self.drones.remove(drone_id)
+            except ValueError:
+                pass
+            self.drone_dict.pop(drone_id, None)
+            logger.debug("Removed drone: %s", drone_id)
 
     def close(self):
-        if self.mqtt_enabled and self.mqtt_client:
+        """Give every sink a chance to cleanup (e.g., stop MQTT loops, flush, etc.)."""
+        for s in self.extra_sinks:
             try:
-                self.mqtt_client.loop_stop()
-                self.mqtt_client.disconnect()
+                if hasattr(s, "close"):
+                    s.close()
             except Exception as e:
-                logger.warning(f"Error shutting down MQTT client: {e}")
+                logger.warning("Error shutting down sink %s: %s", s, e)

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -1,0 +1,414 @@
+"""
+MIT License
+
+Copyright (c) 2025 cemaxecuter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+
+try:
+    import paho.mqtt.client as mqtt
+except Exception as e:
+    mqtt = None  # type: ignore
+
+_log = logging.getLogger(__name__)
+
+
+class MqttSink:
+    """
+    Generic MQTT sink with optional Home Assistant discovery.
+
+    Exposed methods (used by DroneManager):
+      - publish_drone(drone_obj)
+      - publish_pilot(drone_id, lat, lon, alt=0.0)
+      - publish_home(drone_id, lat, lon, alt=0.0)
+      - close()
+
+    Features:
+      - Aggregate JSON publish to a single topic (optional)
+      - Per-drone JSON publish to `<per_drone_base>/<drone_id>` (optional)
+      - HA discovery (optional):
+          * rich per-drone sensors (lat/lon/alt/speed/etc.)
+          * a device_tracker per drone for a clean Map dot
+      - Lightweight in-memory state cache so pilot/home updates merge cleanly.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int = 1883,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        tls: bool = False,
+        ca_file: Optional[str] = None,
+        certfile: Optional[str] = None,
+        keyfile: Optional[str] = None,
+        tls_insecure: bool = False,
+        client_id: Optional[str] = None,
+        keepalive: int = 60,
+        qos: int = 0,
+        # Aggregate / per-drone topics
+        aggregate_topic: Optional[str] = "wardragon/drones",
+        per_drone_enabled: bool = False,
+        per_drone_base: str = "wardragon/drone",
+        retain_state: bool = True,
+        # Home Assistant
+        ha_enabled: bool = False,
+        ha_prefix: str = "homeassistant",
+        ha_device_base: str = "wardragon_drone",
+    ) -> None:
+        if mqtt is None:
+            raise RuntimeError("paho-mqtt not installed but required for MqttSink")
+
+        self.qos = int(qos)
+        self.retain_state = bool(retain_state)
+
+        self.aggregate_topic = aggregate_topic or None
+        self.per_drone_enabled = bool(per_drone_enabled)
+        self.per_drone_base = per_drone_base.strip().strip("/")
+
+        self.ha_enabled = bool(ha_enabled)
+        self.ha_prefix = ha_prefix.strip().strip("/")
+        self.ha_device_base = ha_device_base.strip()
+
+        self._seen_for_ha: set[str] = set()
+        self._state_cache: Dict[str, Dict[str, Any]] = {}
+
+        # --- MQTT client setup ---
+        self.client = mqtt.Client(client_id=client_id, clean_session=True)  # type: ignore
+        try:
+            self.client.enable_logger(_log)  # paho >= 1.6
+        except Exception:
+            pass
+
+        if username is not None:
+            self.client.username_pw_set(username, password)
+
+        if tls:
+            try:
+                self.client.tls_set(
+                    ca_certs=ca_file,
+                    certfile=certfile,
+                    keyfile=keyfile,
+                )
+                self.client.tls_insecure_set(bool(tls_insecure))
+            except Exception as e:
+                _log.critical("MqttSink TLS configuration failed: %s", e)
+                raise
+
+        def _on_connect(c, u, flags, rc, props=None):
+            if rc == 0:
+                _log.info("MqttSink connected to %s:%s", host, port)
+            else:
+                _log.warning("MqttSink connect rc=%s", rc)
+
+        def _on_disconnect(c, u, rc, props=None):
+            _log.info("MqttSink disconnected rc=%s", rc)
+
+        self.client.on_connect = _on_connect
+        self.client.on_disconnect = _on_disconnect
+
+        try:
+            self.client.connect(host, int(port), keepalive=keepalive)
+            self.client.loop_start()
+            # best-effort wait for connection (if supported)
+            is_conn = getattr(self.client, "is_connected", None)
+            deadline = time.time() + 3.0
+            while callable(is_conn) and not self.client.is_connected() and time.time() < deadline:
+                time.sleep(0.05)
+        except Exception as e:
+            _log.critical("MqttSink failed to connect: %s", e)
+            raise
+
+    # ────────────────────────────────────────────────
+    # Public API used by DroneManager
+    # ────────────────────────────────────────────────
+
+    def publish_drone(self, d: Any) -> None:
+        """Publish full drone state (aggregate + per-drone), HA discovery once."""
+        drone_id = str(_get_attr(d, "id", "unknown")) or "unknown"
+
+        # Build a clean, JSON-friendly dict
+        payload = self._drone_to_state(d)
+
+        # Update cache & publish
+        self._merge_and_publish(drone_id, payload)
+
+        # HA discovery (once per drone) — requires per-drone topics
+        if self.ha_enabled and self.per_drone_enabled and drone_id not in self._seen_for_ha:
+            try:
+                state_topic = self._per_drone_topic(drone_id)
+                # device_tracker for clean Map dot
+                self._publish_ha_device_tracker(drone_id, state_topic, payload)
+                # rich sensors for telemetry dashboards
+                self._publish_ha_sensors(drone_id, state_topic, payload)
+                self._seen_for_ha.add(drone_id)
+            except Exception as e:
+                _log.warning("HA discovery failed for %s: %s", drone_id, e)
+
+    def publish_pilot(self, drone_id: str, lat: float, lon: float, alt: float = 0.0) -> None:
+        """Merge pilot fields into the per-drone state and republish (if enabled)."""
+        drone_id = str(drone_id)
+        if drone_id.startswith("pilot-"):
+            drone_id = drone_id[len("pilot-") :]
+
+        patch = {
+            "pilot_lat": _f(lat),
+            "pilot_lon": _f(lon),
+            "pilot_alt": _f(alt),
+        }
+        self._merge_and_publish(drone_id, patch)
+
+    def publish_home(self, drone_id: str, lat: float, lon: float, alt: float = 0.0) -> None:
+        """Merge home fields into the per-drone state and republish (if enabled)."""
+        drone_id = str(drone_id)
+        if drone_id.startswith("home-"):
+            drone_id = drone_id[len("home-") :]
+
+        patch = {
+            "home_lat": _f(lat),
+            "home_lon": _f(lon),
+            "home_alt": _f(alt),
+        }
+        self._merge_and_publish(drone_id, patch)
+
+    def close(self) -> None:
+        """Stop MQTT loop and disconnect cleanly."""
+        try:
+            self.client.loop_stop()
+        except Exception as e:
+            _log.warning("MqttSink loop_stop error: %s", e)
+        try:
+            self.client.disconnect()
+        except Exception as e:
+            _log.warning("MqttSink disconnect error: %s", e)
+
+    # ────────────────────────────────────────────────
+    # Internals
+    # ────────────────────────────────────────────────
+
+    def _merge_and_publish(self, drone_id: str, patch: Dict[str, Any]) -> None:
+        """
+        Merge fields into cache and publish to aggregate/per-drone as configured.
+        """
+        cur = self._state_cache.get(drone_id, {})
+        cur.update(patch)
+        cur["id"] = drone_id
+        self._state_cache[drone_id] = cur
+
+        # Aggregate stream (single topic, all drones as independent messages)
+        if self.aggregate_topic:
+            try:
+                payload = json.dumps(cur, default=_json_default)
+                info = self.client.publish(self.aggregate_topic, payload, qos=self.qos, retain=self.retain_state)
+                self._warn_if_publish_failed(info)
+            except Exception as e:
+                _log.warning("Aggregate publish failed for %s: %s", drone_id, e)
+
+        # Per-drone state (required for HA sensors/device_tracker)
+        if self.per_drone_enabled:
+            try:
+                topic = self._per_drone_topic(drone_id)
+                payload = json.dumps(cur, default=_json_default)
+                info = self.client.publish(topic, payload, qos=self.qos, retain=self.retain_state)
+                self._warn_if_publish_failed(info)
+            except Exception as e:
+                _log.warning("Per-drone publish failed for %s: %s", drone_id, e)
+
+    def _warn_if_publish_failed(self, info) -> None:
+        try:
+            rc = getattr(info, "rc", None)
+            if rc is not None and rc != mqtt.MQTT_ERR_SUCCESS:  # type: ignore
+                _log.warning("MQTT publish returned rc=%s", rc)
+        except Exception:
+            pass
+
+    def _per_drone_topic(self, drone_id: str) -> str:
+        return f"{self.per_drone_base}/{drone_id}"
+
+    def _drone_to_state(self, d: Any) -> Dict[str, Any]:
+        """
+        Convert the Drone object (or dict) into a compact, JSON-friendly state dict.
+        """
+        def g(name, default=None):
+            return _get_attr(d, name, default)
+
+        # freq: allow Hz or MHz; keep raw and also include computed MHz for convenience
+        freq = g("freq", None)
+        freq_mhz = _fmt_freq_mhz(freq)
+
+        state = {
+            "id": g("id", "unknown"),
+            "description": g("description", ""),
+            "lat": _f(g("lat", 0.0)),
+            "lon": _f(g("lon", 0.0)),
+            "alt": _f(g("alt", 0.0)),
+            "height": _f(g("height", 0.0)),
+            "speed": _f(g("speed", 0.0)),
+            "vspeed": _f(g("vspeed", 0.0)),
+            "direction": _f(g("direction", 0.0)),
+            "rssi": _f(g("rssi", 0.0)),
+            "pilot_lat": _f(g("pilot_lat", 0.0)),
+            "pilot_lon": _f(g("pilot_lon", 0.0)),
+            "home_lat": _f(g("home_lat", 0.0)),
+            "home_lon": _f(g("home_lon", 0.0)),
+            "mac": g("mac", ""),
+            "id_type": g("id_type", ""),
+            "ua_type": g("ua_type", None),
+            "ua_type_name": g("ua_type_name", ""),
+            "operator_id_type": g("operator_id_type", ""),
+            "operator_id": g("operator_id", ""),
+            "op_status": g("op_status", ""),
+            "height_type": g("height_type", ""),
+            "ew_dir": g("ew_dir", ""),
+            "timestamp": g("timestamp", ""),
+            "index": g("index", 0),
+            "runtime": g("runtime", 0),
+            # radio
+            "freq": freq,
+            "freq_mhz": freq_mhz,
+        }
+        return state
+
+    # ─────────────────────────── Home Assistant discovery ─────────────────────────
+
+    def _publish_ha_sensors(self, drone_id: str, state_topic: str, sample: Dict[str, Any]) -> None:
+        """
+        Rich per-drone sensors (lat/lon/alt/speed/etc.) — mirrors your ZMQ script style.
+        """
+        base_unique = f"{self.ha_device_base}_{drone_id}"
+        device = {
+            "identifiers": [f"{self.ha_device_base}:{drone_id}"],
+            "name": f"Drone {drone_id}",
+            "manufacturer": "AlphaFox",
+            "model": sample.get("description") or "DragonSync",
+        }
+
+        def sensor(uid_suffix: str, name: str, template: str, unit: Optional[str] = None,
+                   device_class: Optional[str] = None, icon: Optional[str] = None):
+            uid = f"{base_unique}_{uid_suffix}"
+            topic = f"{self.ha_prefix}/sensor/{uid}/config"
+            payload = {
+                "name": name,
+                "state_topic": state_topic,
+                "unique_id": uid,
+                "device": device,
+                "value_template": template,
+            }
+            if unit:
+                payload["unit_of_measurement"] = unit
+            if device_class:
+                payload["device_class"] = device_class
+            if icon:
+                payload["icon"] = icon
+            self.client.publish(topic, json.dumps(payload), qos=self.qos, retain=True)
+
+        # Core kinematics / position
+        sensor("lat", "Latitude", "{{ value_json.lat | float | default(0) }}", "°", icon="mdi:map-marker")
+        sensor("lon", "Longitude", "{{ value_json.lon | float | default(0) }}", "°", icon="mdi:map-marker")
+        sensor("alt", "Altitude", "{{ value_json.alt | float | default(0) }}", "m", device_class="distance", icon="mdi:map-marker-distance")
+        sensor("speed", "Speed", "{{ value_json.speed | float | default(0) }}", "m/s", device_class="speed", icon="mdi:speedometer")
+        sensor("vspeed", "Vertical Speed", "{{ value_json.vspeed | float | default(0) }}", "m/s", icon="mdi:axis-z-arrow")
+        sensor("height", "AGL", "{{ value_json.height | float | default(0) }}", "m", icon="mdi:altimeter")
+        sensor("dir", "Course", "{{ value_json.direction | float | default(0) }}", "°", icon="mdi:compass")
+
+        # Pilot/Home
+        sensor("pilot_lat", "Pilot Latitude", "{{ value_json.pilot_lat | float | default(0) }}", "°", icon="mdi:account")
+        sensor("pilot_lon", "Pilot Longitude", "{{ value_json.pilot_lon | float | default(0) }}", "°", icon="mdi:account")
+        sensor("home_lat", "Home Latitude", "{{ value_json.home_lat | float | default(0) }}", "°", icon="mdi:home")
+        sensor("home_lon", "Home Longitude", "{{ value_json.home_lon | float | default(0) }}", "°", icon="mdi:home")
+
+        # Radio / link
+        sensor("rssi", "Signal (RSSI)", "{{ value_json.rssi | float | default(0) }}", "dBm", device_class="signal_strength", icon="mdi:wifi")
+        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | float | default(none) }}", "MHz", icon="mdi:radio-tower")
+
+        # Metadata (non-numeric; leave device_class empty to keep HA happy)
+        sensor("ua_type", "UA Type", "{{ value_json.ua_type_name | default('') }}", icon="mdi:airplane")
+        sensor("op_id", "Operator ID", "{{ value_json.operator_id | default('') }}", icon="mdi:id-card")
+
+        # A primary "drone" sensor just to show name/description in HA device page
+        sensor("main", "Drone", "{{ value_json.description | default('Drone') }}", icon="mdi:drone")
+
+    def _publish_ha_device_tracker(self, drone_id: str, attr_topic: str, sample: Dict[str, Any]) -> None:
+        """
+        Minimal HA discovery for a map dot: one MQTT device_tracker per drone.
+        We publish 'not_home' on a small /state topic, and the attributes (lat/lon/etc.)
+        live on the per-drone JSON topic.
+        """
+        base_unique = f"{self.ha_device_base}_{drone_id}"
+        device = {
+            "identifiers": [f"{self.ha_device_base}:{drone_id}"],
+            "name": f"Drone {drone_id}",
+            "manufacturer": "AlphaFox",
+            "model": sample.get("description") or "DragonSync",
+        }
+        cfg_topic = f"{self.ha_prefix}/device_tracker/{base_unique}/config"
+        state_topic = f"{attr_topic}/state"
+
+        payload = {
+            "name": f"Drone {drone_id}",
+            "unique_id": base_unique,
+            "device": device,
+            "source_type": "gps",
+            "state_topic": state_topic,           # textual state (we set 'not_home')
+            "json_attributes_topic": attr_topic,  # lat/lon/etc. are attributes
+            "icon": "mdi:drone",
+        }
+        # Retain discovery + default state
+        self.client.publish(cfg_topic, json.dumps(payload), qos=self.qos, retain=True)
+        self.client.publish(state_topic, "not_home", qos=self.qos, retain=True)
+
+
+# ────────────────────────────────────────────────
+# Small helpers
+# ────────────────────────────────────────────────
+
+def _get_attr(obj: Any, name: str, default=None):
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+def _f(x) -> float:
+    try:
+        return float(x)
+    except Exception:
+        return 0.0
+
+def _fmt_freq_mhz(freq: Any) -> Optional[float]:
+    try:
+        f = float(freq)
+    except Exception:
+        return None
+    if f > 1e5:  # looks like Hz
+        f = f / 1e6
+    return round(f, 3)
+
+def _json_default(o):
+    try:
+        return str(o)
+    except Exception:
+        return None

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -355,8 +355,8 @@ class MqttSink:
 
         # Radio / link
         sensor("rssi", "Signal (RSSI)", "{{ value_json.rssi | float | default(0) }}", "dBm", device_class="signal_strength", icon="mdi:wifi")
-        # FIXED: safe default then float conversion to avoid warnings when null
-        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | default(0) | float }}", "MHz", icon="mdi:radio-tower")
+        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | float(0) }}", "MHz", icon="mdi:radio-tower")
+
 
         # Metadata (non-numeric; leave device_class empty to keep HA happy)
         sensor("ua_type", "UA Type", "{{ value_json.ua_type_name | default('') }}", icon="mdi:airplane")

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -361,7 +361,7 @@ class MqttSink:
         base_unique = f"{self.ha_device_base}_{drone_id}"
         device = {
             "identifiers": [f"{self.ha_device_base}:{drone_id}"],
-            "name": "ID",
+            "name": f"{drone_id}",
         }
 
         def sensor(uid_suffix: str, name: str, template: str, unit: Optional[str] = None,
@@ -418,7 +418,7 @@ class MqttSink:
         base_unique = f"{self.ha_device_base}_{drone_id}"
         device = {
             "identifiers": [f"{self.ha_device_base}:{drone_id}"],
-            "name": "ID",
+            "name": f"{drone_id}",
         }
         cfg_topic = f"{self.ha_prefix}/device_tracker/{base_unique}/config"
         state_topic = f"{attr_topic}/state"

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -342,8 +342,8 @@ class MqttSink:
         """
         base_unique = f"{self.ha_device_base}_{drone_id}"
         device = {
-            # Minimal device dict (no "name") to avoid UI duplication like "drone-xyz drone-xyz"
             "identifiers": [f"{self.ha_device_base}:{drone_id}"],
+            "name": "ID",
         }
 
         def sensor(uid_suffix: str, name: str, template: str, unit: Optional[str] = None,
@@ -399,8 +399,8 @@ class MqttSink:
         """
         base_unique = f"{self.ha_device_base}_{drone_id}"
         device = {
-            # Minimal device record (no "name") to avoid duplicate label in UI
             "identifiers": [f"{self.ha_device_base}:{drone_id}"],
+            "name": "ID",
         }
         cfg_topic = f"{self.ha_prefix}/device_tracker/{base_unique}/config"
         state_topic = f"{attr_topic}/state"

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -376,7 +376,7 @@ class MqttSink:
 
         # Radio / link (safe default for None)
         sensor("rssi", "Signal (RSSI)", "{{ value_json.rssi | default(0) | float }}", "dBm", device_class="signal_strength", icon="mdi:wifi")
-        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | default(0) | float }}", "MHz", icon="mdi:radio-tower")
+        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | float(0) }}", "MHz", icon="mdi:radio-tower")
 
         # Metadata (non-numeric; leave device_class empty)
         sensor("ua_type", "UA Type", "{{ value_json.ua_type_name | default('') }}", icon="mdi:airplane")

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -344,7 +344,7 @@ class MqttSink:
 
         # Radio / link
         sensor("rssi", "Signal (RSSI)", "{{ value_json.rssi | float | default(0) }}", "dBm", device_class="signal_strength", icon="mdi:wifi")
-        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | float | default(none) }}", "MHz", icon="mdi:radio-tower")
+        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | default(0) | float }}", "MHz", icon="mdi:radio-tower")
 
         # Metadata (non-numeric; leave device_class empty to keep HA happy)
         sensor("ua_type", "UA Type", "{{ value_json.ua_type_name | default('') }}", icon="mdi:airplane")

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -374,14 +374,13 @@ class MqttSink:
         base_unique = f"{self.ha_device_base}_{drone_id}"
         device = {
             "identifiers": [f"{self.ha_device_base}:{drone_id}"],
-            "name": "Discovered Drone",
             "model": sample.get("description") or "Remote ID",
         }
         cfg_topic = f"{self.ha_prefix}/device_tracker/{base_unique}/config"
         state_topic = f"{attr_topic}/state"
         
         payload = {
-            "name": f"Drone {drone_id} location",  # clear, single label in UI
+            "name": f"{drone_id}",
             "unique_id": base_unique,
             "device": device,
             "source_type": "gps",

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -344,7 +344,7 @@ class MqttSink:
 
         # Radio / link
         sensor("rssi", "Signal (RSSI)", "{{ value_json.rssi | float | default(0) }}", "dBm", device_class="signal_strength", icon="mdi:wifi")
-        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | default(0) | float }}", "MHz", icon="mdi:radio-tower")
+        sensor("freq", "Radio Freq (MHz)", "{{ value_json.freq_mhz | float(0) }}", "MHz", icon="mdi:radio-tower")
 
         # Metadata (non-numeric; leave device_class empty to keep HA happy)
         sensor("ua_type", "UA Type", "{{ value_json.ua_type_name | default('') }}", icon="mdi:airplane")

--- a/mqtt_sink.py
+++ b/mqtt_sink.py
@@ -374,20 +374,19 @@ class MqttSink:
         base_unique = f"{self.ha_device_base}_{drone_id}"
         device = {
             "identifiers": [f"{self.ha_device_base}:{drone_id}"],
-            "name": f"Drone {drone_id}",
-            "manufacturer": "WarDragon",
-            "model": sample.get("description") or "DragonSync",
+            "name": "Discovered Drone",
+            "model": sample.get("description") or "Remote ID",
         }
         cfg_topic = f"{self.ha_prefix}/device_tracker/{base_unique}/config"
         state_topic = f"{attr_topic}/state"
-
+        
         payload = {
-            "name": f"Drone {drone_id}",
+            "name": f"Drone {drone_id} location",  # clear, single label in UI
             "unique_id": base_unique,
             "device": device,
             "source_type": "gps",
-            "state_topic": state_topic,           # textual state (we set 'not_home')
-            "json_attributes_topic": attr_topic,  # lat/longitude/etc. in attributes
+            "state_topic": state_topic,
+            "json_attributes_topic": attr_topic,
             "icon": "mdi:drone",
         }
         # Retain discovery + default state


### PR DESCRIPTION
- Publish per-drone JSON and HA discovery configs
- Create MQTT device_trackers for:
  • drone-<id>
  • pilot-<id-tail>
  • home-<id-tail>
- Add HA sensors (lat/lon/alt/speed/etc.) with safe templates (freq_mhz | float(0))
- Mirror latitude/longitude/gps_accuracy for HA consumption
- Implement availability topics (+ online/offline) and mark_inactive() path
- Keep last-known attributes; hide markers via availability, not attribute deletion
- Maintain aggregate topic; per-drone must be enabled for HA discovery
- No manufacturer branding; device name = <drone_id>
- TLS/MQTT config respected; Lattice unchanged